### PR TITLE
Fixed APIs being ignored, bunch of other tweaks

### DIFF
--- a/UnityXrefMaps/.gitignore
+++ b/UnityXrefMaps/.gitignore
@@ -5,3 +5,4 @@ obj/
 UnityCsReference/
 _site/
 *.cache
+.idea

--- a/UnityXrefMaps/Git.cs
+++ b/UnityXrefMaps/Git.cs
@@ -22,7 +22,7 @@ namespace DocFxForUnity
             bool clone = !Directory.Exists(path);
             if (clone)
             {
-                Console.WriteLine($"Clonning {sourceUrl} to {path}");
+                Console.WriteLine($"Cloning {sourceUrl} to {path}");
 
                 var options = new CloneOptions() { BranchName = branch };
                 Repository.Clone(sourceUrl, path, options);

--- a/UnityXrefMaps/Program.cs
+++ b/UnityXrefMaps/Program.cs
@@ -106,6 +106,8 @@ namespace DocFxForUnity
                     Console.WriteLine("\n");
                 }
             }
+
+            Console.Write("Done.");
         }
 
         /// <summary>
@@ -156,7 +158,13 @@ namespace DocFxForUnity
 
             // Generate site and xref map
             Console.WriteLine($"Running DocFX on '{commit}'");
-            Utils.RunCommand("docfx", output => Console.WriteLine(output), error => Console.WriteLine(error));
+            int docfxExitCode = Utils.RunCommand(
+                "docfx",
+                output => Console.WriteLine("[DocFX] " + output),
+                error => Console.WriteLine("[DocFX - Error] " + error)
+            );
+            if (docfxExitCode != 0)
+                throw new Exception($"docfx command returned exit code {docfxExitCode}");
         }
 
         /// <summary>

--- a/UnityXrefMaps/UnityXrefMaps.csproj
+++ b/UnityXrefMaps/UnityXrefMaps.csproj
@@ -11,4 +11,13 @@
     <PackageReference Include="YamlDotNet" Version="8.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="docfx.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="filterConfig.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/UnityXrefMaps/Utils.cs
+++ b/UnityXrefMaps/Utils.cs
@@ -32,7 +32,8 @@ namespace DocFxForUnity
         /// <param name="command">The command to run.</param>
         /// <param name="output">The function to call with the output data of the command.</param>
         /// <param name="error">The function to call with the error data of the command.</param>
-        public static void RunCommand(string command, Action<string> output, Action<string> error)
+        /// <returns>The exit code of the process.</returns>
+        public static int RunCommand(string command, Action<string> output, Action<string> error)
         {
             using (var process = new Process())
             {
@@ -53,6 +54,7 @@ namespace DocFxForUnity
                 process.BeginErrorReadLine();
 
                 process.WaitForExit();
+                return process.ExitCode;
             }
         }
 
@@ -76,7 +78,7 @@ namespace DocFxForUnity
             }
             catch (HttpRequestException e)
             {
-                Console.WriteLine($"Exception on {uri}: {e.Message}");
+                Console.WriteLine($"Exception on {uri}: {e.Message} {e.InnerException?.Message}");
                 return false;
             }
         }

--- a/UnityXrefMaps/XrefMapReference.cs
+++ b/UnityXrefMaps/XrefMapReference.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using YamlDotNet.Serialization;
 
@@ -40,7 +41,8 @@ namespace DocFxForUnity
         /// <summary>
         /// Gets if this <see cref="XrefMapReference"/> is valid or not.
         /// </summary>
-        public bool IsValid => commentId.Contains("Overload:");
+        [YamlIgnore]
+        public bool IsValid => true;
 
         /// <summary>
         /// Set <see cref="XrefMapReference.href"/> to link to the online API documentation of Unity.
@@ -51,7 +53,7 @@ namespace DocFxForUnity
             string href;
 
             // Namespaces point to documentation index
-            if (commentId.Contains("N:"))
+            if (commentId.StartsWith("N:"))
             {
                 href = "index";
             }
@@ -77,13 +79,25 @@ namespace DocFxForUnity
                 href = Regex.Replace(href, @"\(.*\)", "");
 
                 // Fix href of properties
-                if (commentId.Contains("P:") || commentId.Contains("M:"))
+                if (commentId.StartsWith("P:") || commentId.StartsWith("M:"))
                 {
                     href = Regex.Replace(href, @"\.([a-z].*)$", "-$1");
                 }
             }
 
             this.href = apiUrl + href + ".html";
+        }
+
+        public void FixOverloadCommentId(XrefMapReference[] references)
+        {
+            if (!commentId.StartsWith("Overload:"))
+                return;
+
+            XrefMapReference otherReference = references.FirstOrDefault(otherRef => otherRef != this && otherRef.uid == fullName);
+            if (otherReference != null)
+            {
+                commentId = otherReference.commentId;
+            }
         }
     }
 }

--- a/UnityXrefMaps/filterConfig.yml
+++ b/UnityXrefMaps/filterConfig.yml
@@ -18,5 +18,4 @@ apiRules:
 - exclude:
     uidRegex: Finalize$
 - exclude:
-    hasAttribute:
-        uid: UnityEngine.Internal.ExcludeFromDocsAttribute
+    uidRegex: ^EmbeddedScriptedObjectsTests


### PR DESCRIPTION
- Removed UnityEngine.Internal.ExcludeFromDocsAttribute from exclude filters. Surprisingly many APIs marked with `[ExcludeFromDocs]` actually have an API reference page (for example, `UnityEngine.Object(Object)`).
- Made DocFX output easier to separate from the program output, added DocFX exit code check.
- Configured YAML serializer to omit serializing null values, the output now matches the original `xrefmap.yml` structure line-to-line.
- For some reason, only references with overloads were accounted for, which is plain wrong. As a result, less than third of the API was mapped.
- Reworked `testUrls` so that invalid URLs are excluded from the final references list.
- Fixed `href` generation for some properties and simple overloaded methods.
- I was unable to run the project as-is. Adding `docfx.json` and `filterConfig.yml` to build output fixed it for me.
- Minor other tweaks.