### PR TITLE
chore: update GitHub Actions and GitLab CI workflows

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,18 +5,23 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   # Build the documentation
   build:
-    runs-on: windows-latest # Required by DocFX
+    runs-on: ubuntu-latest # DocFX v2+ is cross-platform; no longer requires Windows
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         # with:
         #   submodules: true
 
       - name: Install DocFX
-        run: choco install -y docfx
+        run: dotnet tool install -g docfx --version 2.77.0
 
       - name: Use README.md as index.md
         run: cp README.md Documentation/index.md
@@ -26,30 +31,18 @@ jobs:
 
       # Upload the generated documentation
       - name: Upload site artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: _site
-          path: _site # Must equals the 'build.dest' value on your docfx.json
+          path: _site # Must equal the 'build.dest' value in docfx.json
 
-  # Deploy the generated documentation to the gh-pages branch
+  # Deploy the generated documentation to GitHub Pages
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        # with:
-        #   submodules: true
-
-      # Download the generated documentation
-      - name: Download site artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: _site
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: _site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,14 +1,13 @@
-image: stefanscherer/chocolatey
-
-before_script:
-  - choco install -y docfx
+image: mcr.microsoft.com/dotnet/sdk:8.0
 
 pages:
   stage: deploy
   script:
-    - mkdir public
-    - copy README.md Documentation\index.md
-    - docfx Documentation\docfx.json
+    - dotnet tool install -g docfx --version 2.77.0
+    - export PATH="$HOME/.dotnet/tools:$PATH"
+    - cp README.md Documentation/index.md
+    - docfx Documentation/docfx.json
+    - mv _site public
   artifacts:
     paths:
       - public


### PR DESCRIPTION
## Summary

### GitHub Actions (`.github/workflows/documentation.yml`)

- Switch build runner from `windows-latest` to `ubuntu-latest` — DocFX v2+ is a cross-platform .NET global tool; Linux runners are faster and billed at half the cost of Windows runners
- Replace Chocolatey install with `dotnet tool install -g docfx --version 2.77.0` — native .NET tool, version pinned for reproducible builds
- Update `actions/checkout@v2` → `actions/checkout@v4` (v2 deprecated)
- Replace third-party `peaceiris/actions-gh-pages@v3` + `upload-artifact@v1` + `download-artifact@v1` with official GitHub Pages actions: `upload-pages-artifact@v3` and `deploy-pages@v4`
- Add workflow-level `permissions` block (`pages: write`, `id-token: write`, `contents: read`) — required by the official deploy action (OIDC-based, no `GITHUB_TOKEN` secret needed)
- Add `environment: github-pages` with deployment URL output in the Actions UI

### GitLab CI (`.gitlab-ci.yml`)

- Switch from `stefanscherer/chocolatey` (Windows image) to `mcr.microsoft.com/dotnet/sdk:8.0` (official Linux image)
- Replace `choco install -y docfx` with `dotnet tool install -g docfx --version 2.77.0` — same version pinning as GitHub Actions
- Fix output path bug: the old config ran `mkdir public` but DocFX output went to `_site/`, leaving `public/` empty; now explicitly moves `_site/` → `public/` after the build
- Replace Windows `copy` command and backslash paths with POSIX `cp` and forward slashes

## Test plan

- [x] Both YAML files pass syntax validation
- [x] In repository Settings → Pages, set source to **"GitHub Actions"** (required one-time change — current source is "Deploy from a branch")
- [ ] Merge this PR and verify the GitHub Actions workflow runs successfully on `main`
- [ ] Confirm the documentation is deployed and accessible at https://normanderwan.github.io/DocFxForUnity/

https://claude.ai/code/session_01HDAawqjLMudEktivP5ifXw