### PR TITLE
docs(readme): document .csproj usage and UNITY_MANAGED_PATH advanced config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,20 @@ online: <https://normanderwan.github.io/DocFxForUnity/>. It references both C# A
 ## Setup your documentation
 
 1. [Install DocFX](https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html#2-use-docfx-as-a-command-line-tool).
-2. Copy the `Documentation/` folder to your Unity project:
+2. Copy the `Documentation/` folder and `DocFxForUnity.csproj` to your Unity project:
 
     ```diff
       .
       ├── Assets
     + ├── Documentation
+    + ├── DocFxForUnity.csproj
       ├── Package
       ├── ProjectSettings
       └── README.md
     ```
+
+    > **Tip:** You may rename `DocFxForUnity.csproj` to match your project name (*e.g.* `YourProject.csproj`).
+    > If you do, also update the `"files": ["DocFxForUnity.csproj"]` entry inside `Documentation/docfx.json`.
 
 3. Edit the following properties in `Documentation/docfx.json`, keep the others as it is:
 
@@ -93,6 +97,9 @@ online: <https://normanderwan.github.io/DocFxForUnity/>. It references both C# A
     - See <https://dotnet.github.io/docfx/tutorial/intro_overwrite_files.html> to know how it works.
 
 9. Generate your documentation:
+    - `DocFxForUnity.csproj` automatically resolves Unity DLLs — no extra setup is needed if Unity Hub is
+      installed at its default location (`C:\Program Files\Unity\Hub` on Windows,
+      `/Applications/Unity/Hub` on macOS, `~/Unity/Hub` on Linux).
     - On a command line opened on your project, run:
 
         ```bash
@@ -118,6 +125,7 @@ If you're using GitHub:
     + |       └── documentation.yml
       ├── Assets
       ├── Documentation
+    + ├── DocFxForUnity.csproj
       ├── Package
       ├── ProjectSettings
       └── README.md
@@ -132,11 +140,30 @@ Generated website is pushed to a `public/` directory. See the
 [GitLab Pages documentation](https://docs.gitlab.com/ee/user/project/pages/getting_started_part_four.html) for more
 details.
 
+## Advanced: custom Unity path (`UNITY_MANAGED_PATH`)
+
+`DocFxForUnity.csproj` resolves Unity DLLs using the following priority order:
+
+| Priority | Source | When used |
+|:--------:|--------|-----------|
+| 1 | `UNITY_MANAGED_PATH` environment variable | Explicit override — use when Unity is **not** in the default Hub path |
+| 2 | `lib/UnityEngine/` in the project root | CI path, automatically populated by the GitHub Actions workflow |
+| 3 | Default Unity Hub installation directory | Auto-detected at build time — no configuration required |
+
+If none of these paths yields any DLL, a build warning is shown with a clear, actionable message.
+
+To use `UNITY_MANAGED_PATH`, point it to the `Managed/UnityEngine` directory of your Unity installation
+before running DocFX:
+
+| OS | Command |
+|----|---------|
+| Windows | `set UNITY_MANAGED_PATH=C:\Program Files\Unity\Hub\Editor\6000.0.0f1\Editor\Data\Managed\UnityEngine` |
+| macOS | `export UNITY_MANAGED_PATH=/Applications/Unity/Hub/Editor/6000.0.0f1/Unity.app/Contents/Managed/UnityEngine` |
+| Linux | `export UNITY_MANAGED_PATH=$HOME/Unity/Hub/Editor/6000.0.0f1/Editor/Data/Managed/UnityEngine` |
+
+Replace `6000.0.0f1` with your installed Unity version, then run DocFX as normal.
+
 ## Troubleshooting / FAQ
-
-- DocFX outputs: `Warning:[ExtractMetadata]No project detected for extracting metadata.`
-
-    Solution: On Unity, click [Asset > Open C# Project](https://docs.microsoft.com/fr-fr/visualstudio/cross-platform/media/vstu_open-csharp-project.png?view=vs-2019) to generate the required `.csproj`.
 
 - DocFX outputs: `Warning:[ExtractMetadata]No metadata is generated for Assembly-CSharp,Assembly-CSharp-Editor.`
 
@@ -147,6 +174,12 @@ details.
       uidRegex: ^Your\.Namespace1
       type: Namespace
     ```
+
+- DocFX outputs a warning that Unity managed DLLs were not found.
+
+    Solution: Set `UNITY_MANAGED_PATH` to your Unity installation's `Managed/UnityEngine` directory
+    (see [Advanced: custom Unity path](#advanced-custom-unity-path-unity_managed_path) above),
+    or install Unity via Unity Hub at its default location.
 
 - If you want to reference a specific version of Unity, change this line on your `docfx.json`:
 
@@ -159,4 +192,4 @@ details.
 ## Disclaimer
 
 This repository is not sponsored by or affiliated with Unity Technologies or its affiliates.
-“Unity” is a trademark or registered trademark of Unity Technologies or its affiliates in the U.S. and elsewhere.
+"Unity" is a trademark or registered trademark of Unity Technologies or its affiliates in the U.S. and elsewhere.


### PR DESCRIPTION
## Summary

Follows on from #33 (the `.csproj` auto-detection rewrite) with the matching README updates:

- **Step 2** now includes `DocFxForUnity.csproj` in the list of files to copy, with a tip on renaming it and keeping `docfx.json` in sync.
- **Step 9** notes that Unity Hub DLLs are auto-detected — no manual "Open C# Project" step needed.
- **"Generate automatically"** section also lists the `.csproj` in the diff block.
- **New "Advanced: custom Unity path (`UNITY_MANAGED_PATH`)"** section explains the three-priority resolution order and shows the exact `set`/`export` commands for Windows, macOS, and Linux.
- **Removed** the outdated troubleshooting tip that told users to open Unity and click *Asset > Open C# Project* to generate a `.csproj`.
- **Added** a replacement troubleshooting entry pointing users to the new advanced section when DLLs are not found.

## Test plan

- [ ] Read through the rendered README on the PR page and verify formatting (tables, diff blocks, code blocks)
- [ ] Confirm the `UNITY_MANAGED_PATH` paths match the globs used in `DocFxForUnity.csproj`
- [ ] Confirm the removed "Open C# Project" tip is gone

https://claude.ai/code/session_01RvaYgaRCD7SfscrxeTynzu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvaYgaRCD7SfscrxeTynzu)_