### PR TITLE
refactor: move DocFxForUnity.csproj into Documentation/

### DIFF
--- a/Documentation/DocFxForUnity.csproj
+++ b/Documentation/DocFxForUnity.csproj
@@ -1,7 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../Assets/**/*.cs" />
+  </ItemGroup>
 
   <Target Name="AddUnityReferences" BeforeTargets="ResolveAssemblyReferences">
     <!--
@@ -14,7 +19,7 @@
     <!-- Priorities 1 & 2: explicit path -->
     <PropertyGroup>
       <UnityManagedPath Condition="'$(UNITY_MANAGED_PATH)' != ''">$(UNITY_MANAGED_PATH)</UnityManagedPath>
-      <UnityManagedPath Condition="'$(UnityManagedPath)' == '' and Exists('$(MSBuildProjectDirectory)/lib/UnityEngine')">$(MSBuildProjectDirectory)/lib/UnityEngine</UnityManagedPath>
+      <UnityManagedPath Condition="'$(UnityManagedPath)' == '' and Exists('$(MSBuildProjectDirectory)/../lib/UnityEngine')">$(MSBuildProjectDirectory)/../lib/UnityEngine</UnityManagedPath>
     </PropertyGroup>
 
     <!-- Collect DLLs from explicit path (priorities 1 or 2) -->

--- a/Documentation/docfx.json
+++ b/Documentation/docfx.json
@@ -3,7 +3,7 @@
         {
             "src": [
                 {
-                    "src": "..",
+                    "src": ".",
                     "files": [
                         "DocFxForUnity.csproj"
                     ]

--- a/README.md
+++ b/README.md
@@ -20,19 +20,18 @@ online: <https://normanderwan.github.io/DocFxForUnity/>. It references both C# A
 ## Setup your documentation
 
 1. [Install DocFX](https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html#2-use-docfx-as-a-command-line-tool).
-2. Copy the `Documentation/` folder and `DocFxForUnity.csproj` to your Unity project:
+2. Copy the `Documentation/` folder to your Unity project:
 
     ```diff
       .
       ├── Assets
-    + ├── DocFxForUnity.csproj
     + ├── Documentation
       ├── Package
       ├── ProjectSettings
       └── README.md
     ```
 
-    You can rename `DocFxForUnity.csproj` to match your project — just update the filename in `Documentation/docfx.json` under `metadata[0].src[0].files` accordingly.
+    You can rename `Documentation/DocFxForUnity.csproj` to match your project — just update the filename in `Documentation/docfx.json` under `metadata[0].src[0].files` accordingly.
 
 3. Edit the following properties in `Documentation/docfx.json`, keep the others as it is:
 
@@ -139,7 +138,7 @@ details.
 
 - DocFX outputs: `Warning:[ExtractMetadata]No project detected for extracting metadata.`
 
-    Solution: Make sure you copied `DocFxForUnity.csproj` (or your renamed version) to the root of your Unity project, and that the filename matches the entry in `Documentation/docfx.json` under `metadata[0].src[0].files`.
+    Solution: Make sure `DocFxForUnity.csproj` (or your renamed version) is inside the `Documentation/` folder, and that the filename matches the entry in `Documentation/docfx.json` under `metadata[0].src[0].files`.
 
 - DocFX outputs: `Warning:[ExtractMetadata]No metadata is generated for Assembly-CSharp,Assembly-CSharp-Editor.`
 
@@ -170,7 +169,7 @@ details.
 
 ## Advanced: `UNITY_MANAGED_PATH`
 
-By default, `DocFxForUnity.csproj` auto-detects the Unity managed DLLs from the standard Unity Hub installation directory. Set `UNITY_MANAGED_PATH` when you need to:
+By default, `Documentation/DocFxForUnity.csproj` auto-detects the Unity managed DLLs from the standard Unity Hub installation directory. Set `UNITY_MANAGED_PATH` when you need to:
 
 - Use a Unity version installed at a non-default location.
 - Pin to a specific version when multiple Unity versions are installed.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Moves `DocFxForUnity.csproj` from the project root into `Documentation/`, so users only need to copy **one folder** to set up documentation instead of a folder plus a separate root-level file.
- Adds an explicit `<Compile Include="../Assets/**/*.cs" />` (with `EnableDefaultCompileItems=false`) since the SDK default glob no longer covers `Assets/` from the new location.
- Fixes the `lib/UnityEngine` CI fallback path to `$(MSBuildProjectDirectory)/../lib/UnityEngine`.
- Updates `Documentation/docfx.json` metadata `src` from `".."` to `"."`.
- Updates `README.md` to reflect the simpler one-folder setup and the new `.csproj` location.

## Test plan

- [ ] Run `docfx Documentation/docfx.json` locally and verify metadata is generated for `Assets/Scripts/Player.cs`
- [ ] Verify the CI workflow (`documentation.yml`) still builds successfully
- [ ] Check that the `lib/UnityEngine` fallback path resolves correctly in CI
- [ ] Confirm renamed `.csproj` scenario still works (rename inside `Documentation/` and update `docfx.json`)

https://claude.ai/code/session_017hjwp9DHW2Sh6ZNhMF2Lbs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017hjwp9DHW2Sh6ZNhMF2Lbs)_